### PR TITLE
[Feat] Adiciona ValidadorDocumento para validação de clientes

### DIFF
--- a/src/dominio/Cliente/ValidadorDocumento.java
+++ b/src/dominio/Cliente/ValidadorDocumento.java
@@ -1,0 +1,27 @@
+package dominio.Cliente;
+
+public class ValidadorDocumento {
+    public static boolean validarCPF(String cpf) {
+        return cpf != null && cpf.length() == 11 && cpf.matches("\\d+");
+    }
+
+    public static boolean validarCNPJ(String cnpj) {
+        return cnpj != null && cnpj.length() == 14 && cnpj.matches("\\d+");
+    }
+
+    public static String formatarCPF(String cpf) {
+        if (validarCPF(cpf)) {
+            return cpf.substring(0, 3) + "." + cpf.substring(3, 6) + "." +
+                    cpf.substring(6, 9) + "-" + cpf.substring(9);
+        }
+        return "CPF inválido";
+    }
+
+    public static String formatarCNPJ(String cnpj) {
+        if (validarCNPJ(cnpj)) {
+            return cnpj.substring(0, 2) + "." + cnpj.substring(2, 5) + "." +
+                    cnpj.substring(5, 8) + "/" + cnpj.substring(8, 12) + "-" + cnpj.substring(12);
+        }
+        return "CNPJ inválido";
+    }
+}


### PR DESCRIPTION
### Adiciona ValidadorDocumento para validação e formatação de CPF e CNPJ  

#### O que foi feito:  
- Criada a classe `ValidadorDocumento` para validar e formatar documentos.  
- Métodos implementados:  
  - `validarCPF(String cpf)`:  
    - Verifica se o CPF não é nulo.  
    - Confere se contém exatamente 11 caracteres.  
    - Garante que todos os caracteres sejam dígitos (`0-9`).  
  - `validarCNPJ(String cnpj)`:  
    - Verifica se o CNPJ não é nulo.  
    - Confere se contém exatamente 14 caracteres.  
    - Garante que todos os caracteres sejam dígitos (`0-9`).  
  - `formatarCPF(String cpf)`:  
    - Chama `validarCPF` antes de formatar.  
    - Aplica a formatação padrão: `XXX.XXX.XXX-XX`.  
    - Retorna `"CPF inválido"` caso a validação falhe.  
  - `formatarCNPJ(String cnpj)`:  
    - Chama `validarCNPJ` antes de formatar.  
    - Aplica a formatação padrão: `XX.XXX.XXX/XXXX-XX`.  
    - Retorna `"CNPJ inválido"` caso a validação falhe.  

#### Objetivo:  
Garantir que os documentos cadastrados sejam válidos e estejam corretamente formatados para exibição.