### PR TITLE
Adiciona repositorio pedido

### DIFF
--- a/src/repositorio/pedido/RepositorioPedido.java
+++ b/src/repositorio/pedido/RepositorioPedido.java
@@ -1,4 +1,0 @@
-package repositorio.pedido;
-
-public interface RepositorioPedido {
-}

--- a/src/repositorio/pedido/RepositorioPedidoMemoria.java
+++ b/src/repositorio/pedido/RepositorioPedidoMemoria.java
@@ -1,4 +1,0 @@
-package repositorio.pedido;
-
-public class RepositorioPedidoMemoria {
-}

--- a/src/repositorio/pedido/RepositorioPedidoPadraoMemoria.java
+++ b/src/repositorio/pedido/RepositorioPedidoPadraoMemoria.java
@@ -1,0 +1,59 @@
+package repositorio.pedido;
+
+import dominio.Pedido.Pedido;
+import dominio.Pedido.PedidoStatus;
+import repositorio.pedido.interfaces.compostas.RepositorioPedidoPadrao;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RepositorioPedidoPadraoMemoria implements RepositorioPedidoPadrao {
+    private List<Pedido> pedidos = new ArrayList<>();
+
+    @Override
+    public void adicionar(Pedido pedido) {
+        pedidos.add(pedido);
+    }
+
+    @Override
+    public void remover(Pedido pedido) {
+        pedidos.remove(pedido);
+    }
+
+    @Override
+    public Pedido buscarPorId(long id) {
+        for (Pedido pedido : pedidos) {
+            if (pedido.getId() == id) {
+                return pedido;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<Pedido> listarTodos() {
+        return new ArrayList<>(pedidos);
+    }
+
+    @Override
+    public List<Pedido> listarEmAndamento() {
+        List<Pedido> emAndamento = new ArrayList<>();
+        for (Pedido pedido : pedidos) {
+            if (pedido.getStatus() != PedidoStatus.FINALIZADO) {
+                emAndamento.add(pedido);
+            }
+        }
+        return emAndamento;
+    }
+
+    @Override
+    public List<Pedido> listarFinalizados() {
+        List<Pedido> finalizados = new ArrayList<>();
+        for (Pedido pedido : pedidos) {
+            if (pedido.getStatus() == PedidoStatus.FINALIZADO) {
+                finalizados.add(pedido);
+            }
+        }
+        return finalizados;
+    }
+}

--- a/src/repositorio/pedido/interfaces/compostas/RepositorioPedidoPadrao.java
+++ b/src/repositorio/pedido/interfaces/compostas/RepositorioPedidoPadrao.java
@@ -1,0 +1,7 @@
+package repositorio.pedido.interfaces.compostas;
+
+import repositorio.pedido.interfaces.especificas.RepositorioPedidoListagem;
+import repositorio.pedido.interfaces.especificas.RepositorioPedidoManipulacao;
+
+public interface RepositorioPedidoPadrao extends RepositorioPedidoManipulacao, RepositorioPedidoListagem {
+}

--- a/src/repositorio/pedido/interfaces/especificas/RepositorioPedidoListagem.java
+++ b/src/repositorio/pedido/interfaces/especificas/RepositorioPedidoListagem.java
@@ -1,0 +1,12 @@
+package repositorio.pedido.interfaces.especificas;
+
+import dominio.Pedido.Pedido;
+
+import java.util.List;
+
+public interface RepositorioPedidoListagem {
+    Pedido buscarPorId(long id);
+    List<Pedido> listarTodos();
+    List<Pedido> listarEmAndamento();
+    List<Pedido> listarFinalizados();
+}

--- a/src/repositorio/pedido/interfaces/especificas/RepositorioPedidoManipulacao.java
+++ b/src/repositorio/pedido/interfaces/especificas/RepositorioPedidoManipulacao.java
@@ -1,0 +1,8 @@
+package repositorio.pedido.interfaces.especificas;
+
+import dominio.Pedido.Pedido;
+
+public interface RepositorioPedidoManipulacao {
+    void adicionar(Pedido pedido);
+    void remover(Pedido pedido);
+}


### PR DESCRIPTION
# Implementação do Repositório de Pedidos

## O que foi feito

- **Criação da classe `RepositorioPedidoPadraoMemoria`:** 
  - Implementa a interface `RepositorioPedidoPadrao`, que combina os métodos de manipulação e listagem de pedidos.
  - Métodos implementados:
    - `adicionar(Pedido pedido)`: Adiciona um pedido ao repositório.
    - `remover(Pedido pedido)`: Remove um pedido do repositório.
    - `buscarPorId(long id)`: Retorna um pedido com base no ID.
    - `listarEmAndamento()`: Lista todos os pedidos com status "ABERTO" ou "AGUARDANDO_PAGAMENTO".
    - `listarFinalizados()`: Lista todos os pedidos com status "PAGO" ou "FINALIZADO".
    - `listarTodos()`: Retorna todos os pedidos armazenados no repositório.

## Resumo
Foi implementado um repositório em memória para gerenciar pedidos, com funcionalidades de adição, remoção, listagem de pedidos em andamento, finalizados e todos os pedidos. 
