### PR TITLE
Adiciona validador pedido

### DIFF
--- a/src/dominio/Pedido/Pedido.java
+++ b/src/dominio/Pedido/Pedido.java
@@ -10,12 +10,11 @@ import java.util.List;
 
 public abstract class Pedido implements PedidoModificacao{
     private static long contador = 1;
-
-    protected final long id;
-    protected Cliente cliente;
-    protected List<ItemPedido> itens;
-    protected LocalDateTime dataCriacao;
-    protected PedidoStatus status;
+    private final long id;
+    private Cliente cliente;
+    private List<ItemPedido> itens;
+    private LocalDateTime dataCriacao;
+    private PedidoStatus status;
 
     public Pedido(Cliente cliente) {
         this.id = contador++;
@@ -24,8 +23,6 @@ public abstract class Pedido implements PedidoModificacao{
         this.dataCriacao = LocalDateTime.now();
         this.status = PedidoStatus.ABERTO;
     }
-
-    public abstract void validarPedido();
 
     public abstract void adicionarItem(Produto produto, int quantidade, double valorVenda);
 

--- a/src/dominio/Pedido/ValidaPedido.java
+++ b/src/dominio/Pedido/ValidaPedido.java
@@ -1,0 +1,39 @@
+package dominio.Pedido;
+
+import dominio.Pedido.ItemPedido;
+import dominio.Pedido.Pedido;
+import dominio.Produto.Produto;
+
+public class ValidaPedido implements ValidadorPedido {
+
+    @Override
+    public boolean itemExiste(Pedido pedido, Produto produto) {
+        for (ItemPedido item : pedido.getItens()) {
+            if (item.getProduto().equals(produto)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void validarAdicaoItem(Pedido pedido, Produto produto) {
+        if (itemExiste(pedido, produto)) {
+            throw new IllegalArgumentException("O produto já foi adicionado ao pedido.");
+        }
+    }
+
+    @Override
+    public void validarRemocaoItem(Pedido pedido, Produto produto) {
+        if (!itemExiste(pedido, produto)) {
+            throw new IllegalArgumentException("O item já foi removido ou não existe no pedido.");
+        }
+    }
+
+    @Override
+    public void validarAlteracaoQuantidade(Pedido pedido, Produto produto) {
+        if (!itemExiste(pedido, produto)) {
+            throw new IllegalArgumentException("O item não existe no pedido.");
+        }
+    }
+}

--- a/src/dominio/Pedido/ValidadorPedido.java
+++ b/src/dominio/Pedido/ValidadorPedido.java
@@ -1,0 +1,9 @@
+package dominio.Pedido;
+import dominio.Produto.Produto;
+
+public interface ValidadorPedido {
+    boolean itemExiste(Pedido pedido, Produto produto);
+    void validarAdicaoItem(Pedido pedido, Produto produto);
+    void validarRemocaoItem(Pedido pedido, Produto produto);
+    void validarAlteracaoQuantidade(Pedido pedido, Produto produto);
+}


### PR DESCRIPTION
## Impedir Adição, Remoção e Alteração de Produtos no Pedido

### O que foi feito:

- **Validações Implementadas**:
  - **ValidaPedido (Interface)**: Define os métodos para validação de operações com itens no pedido.
    - `validarAdicaoItem`: Impede a adição de um produto já presente no pedido.
    - `validarRemocaoItem`: Impede a remoção de um produto que não está no pedido.
    - `validarAlteracaoQuantidade`: Impede a alteração da quantidade de um produto que não está no pedido.
  
- **ValidaPedido (Classe)**: Implementa a interface `ValidadorPedido`, fornecendo a lógica para validação:
  - Verifica se o produto existe no pedido antes de permitir a adição, remoção ou alteração.
  - Lança exceções (`IllegalArgumentException`) com mensagens apropriadas caso a validação falhe.

- **PedidoPadrao (Classe)**:
  - **Métodos alterados**:
    - `adicionarItem`: Verifica se o produto já foi adicionado usando o validador, e impede a adição duplicada.
    - `removerItem`: Verifica se o produto está presente antes de permitir a remoção.
    - `alterarQuantidadeItem`: Verifica se o produto existe no pedido antes de permitir a alteração da quantidade.

### Resumo:

A implementação do validador `ValidaPedido` em `PedidoPadrao` garante que as operações de adicionar, remover ou alterar produtos no pedido sejam feitas com validação prévia. Se um produto já foi adicionado, está ausente ou não existe, a operação será impedida, mantendo a integridade do pedido.